### PR TITLE
Fixed typos

### DIFF
--- a/_includes/HTML6.md
+++ b/_includes/HTML6.md
@@ -92,7 +92,7 @@ All of the following tags in this API have the namespace `html` like: `<html:tit
 
 ##### `<html:html>`
 
-This begins a HTML document. Equivelent to the current `<html>` tag.
+This begins a HTML document. Equivalent to the current `<html>` tag.
 
 _Example:_
 
@@ -104,7 +104,7 @@ _Example:_
 ```
 ##### `<html:head>`
 
-This begins an HTML's head. Equivelent to the current `<html>` tag. The tag contains data that isn't actually displayed (aside from the `<html:title>` which is displayed in the browser's windows). Rather, it's purpose is to get data and scripts that affect the display of the content in the `<html:body>`. These scripts and other sources include things like JavaScript, CSS, RSS feeds, etc.
+This begins an HTML's head. Equivalent to the current `<head>` tag. The tag contains data that isn't actually displayed (aside from the `<html:title>` which is displayed in the browser's windows). Rather, it's purpose is to get data and scripts that affect the display of the content in the `<html:body>`. These scripts and other sources include things like JavaScript, CSS, RSS feeds, etc.
 
 _Example:_
 


### PR DESCRIPTION
html:head refers to head, not html
Typo: equivelent to equivalent
